### PR TITLE
Resolved issue #13

### DIFF
--- a/app/src/main/java/project/dscjss/plasmadonor/Activity/SplashActivity.kt
+++ b/app/src/main/java/project/dscjss/plasmadonor/Activity/SplashActivity.kt
@@ -3,6 +3,7 @@ package project.dscjss.plasmadonor.Activity
 import android.content.Intent
 import android.os.Bundle
 import android.os.Handler
+import android.os.Looper
 import androidx.appcompat.app.AppCompatActivity
 import com.google.firebase.auth.FirebaseAuth
 import project.dscjss.plasmadonor.R
@@ -17,7 +18,7 @@ class SplashActivity : AppCompatActivity() {
 
         firebaseAuth = FirebaseAuth.getInstance()
 
-        Handler().postDelayed({
+        Handler(Looper.getMainLooper()).postDelayed({
             if (firebaseAuth.currentUser != null) {
                 startActivity(Intent(applicationContext , MainActivity::class.java))
             }


### PR DESCRIPTION
Fixes #13 
Checklist:

- [x] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [x] I have read the [Contribution & Best practices Guide](https://github.com/DSC-JSS-NOIDA/Plasma-Donor-App/blob/master/CONTRIBUTING.md) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

Changes: 
The default `Handler()` was deprecated because it can - 
- lead to bugs where operations are silently lost (if the Handler is not expecting new tasks and quits)
- crashes (if a handler is sometimes created on a thread without a Looper active)
- race conditions

So, to avoid using deprecated methods, the official android dev page suggested to use `Looper.getMainLooper()` instead of the default constructor `Handler()`

Read more at official [Android Dev Page](https://developer.android.com/reference/android/os/Handler#Handler()) about deprecation.

Screenshots for the change:

![image](https://user-images.githubusercontent.com/20818641/94761758-761c3c00-03c3-11eb-83c5-724bf386509a.png)

