### PR TITLE
Hide Notification bar from Splash Screen 

### DIFF
--- a/app/src/main/java/project/dscjss/plasmadonor/Activity/SplashActivity.kt
+++ b/app/src/main/java/project/dscjss/plasmadonor/Activity/SplashActivity.kt
@@ -1,9 +1,12 @@
 package project.dscjss.plasmadonor.Activity
 
 import android.content.Intent
+import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.WindowInsets
+import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
 import com.google.firebase.auth.FirebaseAuth
 import project.dscjss.plasmadonor.R
@@ -14,7 +17,9 @@ class SplashActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+
+        hideStatusBar()
+        setContentView(R.layout.activity_splash)
 
         firebaseAuth = FirebaseAuth.getInstance()
 
@@ -27,6 +32,16 @@ class SplashActivity : AppCompatActivity() {
             }
             finish()
         }, 2500)
+    }
 
+    private fun hideStatusBar() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            window.insetsController?.hide(WindowInsets.Type.statusBars())
+        } else {
+            window.setFlags(
+                WindowManager.LayoutParams.FLAG_FULLSCREEN,
+                WindowManager.LayoutParams.FLAG_FULLSCREEN
+            )
+        }
     }
 }

--- a/app/src/main/res/layout/activity_splash.xml
+++ b/app/src/main/res/layout/activity_splash.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorPrimary"
+    android:gravity="center_vertical|center_horizontal"
+    android:orientation="vertical">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:fontFamily="sans-serif-condensed-medium"
+        android:text="@string/plasma_donor"
+        android:textColor="@android:color/white"
+        android:textSize="32sp" />
+
+</LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -13,4 +13,5 @@
     <string name="verify_screen_logo">Verify Screen Logo</string>
     <string name="open">Open</string>
     <string name="close">Close</string>
+    <string name="plasma_donor">PLASMA DONOR</string>
 </resources>


### PR DESCRIPTION
- Fixed status bar issue on splash screen

Fixes #11 
Checklist:

- [x] I have checked for PMD and check-style issues 
- [x] I have read the [Contribution & Best practices Guide](https://github.com/DSC-JSS-NOIDA/Plasma-Donor-App/blob/master/CONTRIBUTING.md) and my PR follows them.
- [x] My branch is up-to-date with the Upstream development branch.

- Added activity_splash layout and linked with Splash Activity.
- Removed status bar on splash screen.
- Added App name on Splash screen and background color.

Screenshots for the change:
![device-2020-10-02-193048](https://user-images.githubusercontent.com/46890586/94942028-2aff4780-04ef-11eb-974e-65c8904dc995.png)
