### PR TITLE
prevent multiple line in input name field

### DIFF
--- a/app/src/main/res/layout/patient_form_fragment.xml
+++ b/app/src/main/res/layout/patient_form_fragment.xml
@@ -26,7 +26,10 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="10dp"
-                android:layout_marginEnd="16dp" />
+                android:layout_marginEnd="16dp"
+                android:maxLines="1"
+                android:inputType="text"
+                />
 
             <EditText
                 android:id="@+id/etBloodGrp"


### PR DESCRIPTION
Fixes #16 
Checklist:

- [ ✅ ] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [ ✅ ] I have read the [Contribution & Best practices Guide](https://github.com/DSC-JSS-NOIDA/Plasma-Donor-App/blob/master/CONTRIBUTING.md) and my PR follows them.
- [ ✅ ] My branch is up-to-date with the Upstream development branch.

Changes: Add attribute **android:maxLines="1"** and **android:inputType="text"** to prevent multilines in input name field

Screenshots for the change:
<img width="330" alt="Screenshot 2020-10-02 at 23 36 31" src="https://user-images.githubusercontent.com/14243792/94947614-1bd8c380-0508-11eb-9b2e-1228a9a0ffcd.png">
