### PR TITLE
make keyboard only show number to input age & phone number in patient…

### DIFF
--- a/app/src/main/res/layout/patient_form_fragment.xml
+++ b/app/src/main/res/layout/patient_form_fragment.xml
@@ -45,7 +45,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="10dp"
-                android:layout_marginEnd="16dp" />
+                android:layout_marginEnd="16dp"
+                android:inputType="number"/>
 
             <EditText
                 android:id="@+id/etGender"
@@ -82,7 +83,8 @@
                 android:layout_height="wrap_content"
                 android:layout_marginStart="16dp"
                 android:layout_marginTop="10dp"
-                android:layout_marginEnd="16dp" />
+                android:layout_marginEnd="16dp"
+                android:inputType="number"/>
 
             <EditText
                 android:id="@+id/etEmail"


### PR DESCRIPTION
… form screen

Fixes #45 
Checklist:

- [✅] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [✅] I have read the [Contribution & Best practices Guide](https://github.com/DSC-JSS-NOIDA/Plasma-Donor-App/blob/master/CONTRIBUTING.md) and my PR follows them.
- [✅] My branch is up-to-date with the Upstream development branch.

Changes: set attribute input type to number in **EditText Age** and **EditText Mobile** in add patient form screen

Screenshots for the change:
<img width="322" alt="Screenshot 2020-10-02 at 23 49 13" src="https://user-images.githubusercontent.com/14243792/94949725-98b96c80-050b-11eb-9f1b-44731d0b8217.png">
