### PR TITLE
move function hideStatusBar() after view attach & give suppress depre…

### DIFF
--- a/app/src/main/java/project/dscjss/plasmadonor/Activity/SplashActivity.kt
+++ b/app/src/main/java/project/dscjss/plasmadonor/Activity/SplashActivity.kt
@@ -5,6 +5,7 @@ import android.os.Build
 import android.os.Bundle
 import android.os.Handler
 import android.os.Looper
+import android.view.View
 import android.view.WindowInsets
 import android.view.WindowManager
 import androidx.appcompat.app.AppCompatActivity
@@ -18,8 +19,9 @@ class SplashActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
-        hideStatusBar()
         setContentView(R.layout.activity_splash)
+
+        hideStatusBar()
 
         firebaseAuth = FirebaseAuth.getInstance()
 
@@ -34,6 +36,7 @@ class SplashActivity : AppCompatActivity() {
         }, 2500)
     }
 
+    @Suppress("DEPRECATION")
     private fun hideStatusBar() {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
             window.insetsController?.hide(WindowInsets.Type.statusBars())


### PR DESCRIPTION
…ciation to inspect deprecated FLAG_FULLSCREEN

Fixes #53 

Checklist:

- [✅] I have checked for PMD and check-style issues <!-- please add a note if a false warning could not be suppressed -->
- [✅] I have read the [Contribution & Best practices Guide](https://github.com/DSC-JSS-NOIDA/Plasma-Donor-App/blob/master/CONTRIBUTING.md) and my PR follows them.
- [✅] My branch is up-to-date with the Upstream development branch.

Changes: move function hideStatusBar() after view attach & give suppress depreciation to inspect deprecated FLAG_FULLSCREEN

Screenshots for the change:
now, work fine on Emulator API 30 like below picture
<img width="324" alt="Screenshot 2020-10-04 at 13 37 10" src="https://user-images.githubusercontent.com/14243792/95008737-b8a17b00-0646-11eb-815e-9abb82eb53ac.png">
